### PR TITLE
Allow more digits input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Syntax for a duration is `__h__m__s` where the hour, minute and second values ar
 - 10hrs 5secs - `10h5s`
 - 1hr 25mins 45secs - `1h25m45s`
 
+### Updated examples
+
+- 2min 40mins - `165m`
+- 10hrs 50 mins - `650m`
+- you can do 999h or 999s as well
+
 ### Options
 
 #### --no-bell

--- a/timer/__main__.py
+++ b/timer/__main__.py
@@ -51,7 +51,8 @@ def createTimeString(hrs: Number, mins: Number, secs: Number) -> str:
 def parseDurationString(
     duration_str: str,
 ) -> Tuple[bool, Union[List[Optional[str]], str]]:
-    duration_regex = re.compile(r"([0-9]{1,2}h)?([0-9]{1,2}m)?([0-9]{1,2}s)?")
+    # Updated regex to allow more digits for hours, minutes, and seconds
+    duration_regex = re.compile(r"([0-9]+h)?([0-9]+m)?([0-9]+s)?")
     match = duration_regex.match(duration_str)
     if match and any(match.groups()):
         return True, list(match.groups())


### PR DESCRIPTION
I  use the timer with the `shutdown` command and usually set it in minutes. But having to convert minutes to hours every time was a bit annoying.

So I changed the input to allow more digits, making it easier to just type the number of minutes directly.