### PR TITLE
Support datetime input and improve font handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,20 @@ $ timer [options] duration
 
 ### How to specify a duration
 
-Syntax for a duration is `__h__m__s` where the hour, minute and second values are all optional.
+The duration of your timer can be either:
+  - A duration string (`__h__m__s`)
+  - An absolute datetime (`YYYY-MM-DD`, or `YYYY-MM-DDTHH:MM:SS`)
+  - A time only, meaning the next occurrence (`THH:MM:SS`)
 
 #### Duration examples
 
-- 2mins 30secs - `2m30s`
-- 10hrs 5secs - `10h5s`
-- 1hr 25mins 45secs - `1h25m45s`
+```bash
+timer 1h30m #1hr 30mins
+timer 25m #25mins
+timer 15m30s #15mins 30secs
+timer 2026-01-25T14:00
+timer T14:00
+```
 
 ### Options
 
@@ -41,6 +48,13 @@ Use this flag to specify a message to display under the timer. Make sure to surr
 ```bash
 $ timer 1h30m -m "Review the pull requests"
 ```
+
+#### --font
+You can customize the font used to render the timer with 
+```bash 
+timer --font <font_name> duration
+```
+Check for available fonts with `timer --list-fonts`
 
 ## Contributing
 

--- a/timer/__main__.py
+++ b/timer/__main__.py
@@ -137,8 +137,8 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
     \b
     DURATION is the duration of your timer. It can be either:
         - A duration string (__h__m__s)
-        - An absolute datetime (YYYY-MM-DDTHH:MM)
-        - A time only, meaning the next occurrence (T14:00)
+        - An absolute datetime (YYYY-MM-DDTHH:MM:SS)
+        - A time only, meaning the next occurrence (THH:MM:SS)
 
     \b
     Example usage:

--- a/timer/__main__.py
+++ b/timer/__main__.py
@@ -226,7 +226,7 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
 
     countdown_time_string = createTimeString(hours, minutes, seconds - 1)
     countdown_time_text = Text(
-        text2art(countdown_time_string, font=font), style=TEXT_COLOUR_HIGH_PERCENT
+        text2art(countdown_time_string, font=font).rstrip("\n"), style=TEXT_COLOUR_HIGH_PERCENT
     )
 
     message_text = Text(message, style="cyan")
@@ -237,7 +237,7 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
         .maximum,
     )
 
-    display_text = Text.assemble(countdown_time_text, message_text)
+    display_text = Text.assemble(countdown_time_text, Text("\n"), message_text)
 
     display = Align.center(display_text, vertical="middle", height=console.height + 1)
 
@@ -260,7 +260,7 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
                     (remaining_time // 60) % 60,
                     remaining_time % 60,
                 )
-                remaining_time_text = Text(text2art(remaining_time_string, font=font))
+                remaining_time_text = Text(text2art(remaining_time_string, font=font).rstrip("\n"))
 
                 time_difference_percentage = remaining_time / time_difference_secs
 
@@ -285,7 +285,7 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
                     .maximum,
                 )
 
-                display_text = Text.assemble(remaining_time_text, message_text)
+                display_text = Text.assemble(remaining_time_text, Text("\n"), message_text)
 
                 display = Align.center(
                     display_text, vertical="middle", height=console.height + 1


### PR DESCRIPTION
This PR introducing absolute datetime support, font customization via CLI flags, and a font discovery feature grouped by approximate size.
All existing duration-based behavior remains fully backward-compatible.

## New Features
1. Absolute datetime timers

The timer can now be started using a target date/time instead of a duration.
Supported formats:
- `YYYY-MM-DD`
- `YYYY-MM-DDTHH`
- `YYYY-MM-DDTHH:MM`
- `YYYY-MM-DDTHH:MM:SS`
- `THH:MM` → next occurrence of that time (today or tomorrow)

Examples:
```bash
timer 2026-01-25T14:00
timer T14:00
```
2. `--font` CLI option

Fonts can now be selected directly via a command-line option, overriding the TIMER_FONT environment variable.
```bash
timer 25m --font doom
```
And now invalid font names are validated with a error message.

3. `--list-fonts`: discover available fonts

A new flag lists all fonts provided by the art package.
Fonts are grouped by approximate size, inferred from their rendered height: normal (1), tiny (<=2), small (<=4), medium (<=7), large (<=9) and huge (>9).

Each font is previewed using a sample timer string for easy comparison.
```bash
timer --list-fonts
```