### PR TITLE
Adds an option to auto close at finish

### DIFF
--- a/timer/__main__.py
+++ b/timer/__main__.py
@@ -297,9 +297,9 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
                             target_time += now - paused_at
 
                 if paused:
-                    remaining_time = math.floor(target_time - paused_at)
+                    remaining_time = math.ceil(target_time - paused_at)
                 else:
-                    remaining_time = math.floor(target_time - now)
+                    remaining_time = math.ceil(target_time - now)
 
                 remaining_time_string = createTimeString(
                     remaining_time // 3600,

--- a/timer/__main__.py
+++ b/timer/__main__.py
@@ -156,6 +156,12 @@ def parseDurationString(
     help="Do not ring the terminal bell once the timer is over",
 )
 @click.option(
+    "--auto-close",
+    default=False,
+    is_flag=True,
+    help="Auto-close on timer finish",
+)
+@click.option(
     "--days",
     default=False,
     is_flag=True,
@@ -173,7 +179,7 @@ def parseDurationString(
     is_flag=True,
     help="List available fonts and exit",
 )
-def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_fonts: bool, days: bool) -> None:
+def main(duration: Optional[str], no_bell: bool, auto_close: bool, message: str, font: str, list_fonts: bool, days: bool) -> None:
     """
     \b
     DURATION is the duration of your timer. It can be either:
@@ -345,7 +351,7 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
                 time.sleep(1)
 
         with console.screen(style="bold white on red") as screen:
-            while True:
+            while not auto_close:
                 if not no_bell:
                     console.bell()
 

--- a/timer/__main__.py
+++ b/timer/__main__.py
@@ -255,24 +255,7 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
         console.print(f"[red]The timer duration cannot be zero.[/red]")
         sys.exit(1)
 
-    countdown_time_string = createTimeString(hours, minutes, seconds)
-    countdown_time_text = Text(
-        text2art(countdown_time_string, font=font).rstrip("\n"), style=TEXT_COLOUR_HIGH_PERCENT
-    )
-
-    message_text = Text(message, style="cyan")
-    message_text.align(
-        "center",
-        Measurement.get(console, console.options, countdown_time_text)
-        .normalize()
-        .maximum,
-    )
-
-    display_text = Text.assemble(countdown_time_text, Text("\n"), message_text)
-
-    display = Align.center(display_text, vertical="middle", height=console.height + 1)
-
-    start_time = math.floor(time.time())
+    start_time = time.time()
 
     target_time = start_time + (hours * 3600) + (minutes * 60) + seconds
     initial_duration = target_time - start_time
@@ -281,8 +264,9 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
     paused_at = None
     last_remaining_time = None
 
+    initial_display = Align.center(Text(" "), vertical="middle", height=console.height + 1)
     try:
-        with raw_stdin(), Live(display, screen=True) as live:
+        with raw_stdin(), Live(initial_display, screen=True) as live:
             while True:
                 now = time.time()
                 
@@ -297,9 +281,9 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
                             target_time += now - paused_at
 
                 if paused:
-                    remaining_time = math.ceil(target_time - paused_at)
+                    remaining_time = math.max(0, math.ceil(target_time - paused_at))
                 else:
-                    remaining_time = math.ceil(target_time - now)
+                    remaining_time = math.max(0, math.ceil(target_time - now))
 
                 remaining_time_string = createTimeString(
                     remaining_time // 3600,

--- a/timer/__main__.py
+++ b/timer/__main__.py
@@ -343,7 +343,7 @@ def main(duration: Optional[str], no_bell: bool, message: str, font: str, list_f
                 time.sleep(1)
 
         with console.screen(style="bold white on red") as screen:
-            while False:
+            while True:
                 if not no_bell:
                     console.bell()
 


### PR DESCRIPTION
A really simple change. I just added a boolean argument `--auto-close` and used `not --auto-close` instead of `True` in the final blink loop `00:00:00`. This makes the timer usable with `&&` pipelines.

For example, now it is possible to use it to schedule a task and see the timer to the task, with
```bash
timer 10s --auto-close && ffplay ~/alarm.mp3
```

Ah, you will notice that I checkout from my own main to create it. But don't worry, it is just the last commit. If you choose to not accept the other features, we can change this pull request to just this single commit :)